### PR TITLE
fix(create): Fix create to dashboard

### DIFF
--- a/frontend/components/contract-interaction-dialog-context.tsx
+++ b/frontend/components/contract-interaction-dialog-context.tsx
@@ -3,9 +3,11 @@ import {
   Box,
   Dialog,
   DialogTitle,
+  DialogContentText,
   Step,
   StepLabel,
   Stepper,
+  DialogContent,
 } from "@mui/material";
 
 type StepDescriptions = Record<string, string>;
@@ -58,8 +60,13 @@ export const ContractInteractionDialogProvider: React.FC<PropsWithChildren> = ({
           console.log("Manual closing of dialog disabled");
         }}
         disableEscapeKeyDown={true}
+        fullWidth={true}
       >
         <DialogTitle>Contract interaction</DialogTitle>
+
+        <DialogContent>
+          <DialogContentText>Please keep this tab open until completion</DialogContentText>
+        </DialogContent>
 
         <Box sx={{ px: 3, pb: 3 }}>
           <Stepper

--- a/frontend/components/hypercert-create.tsx
+++ b/frontend/components/hypercert-create.tsx
@@ -319,11 +319,14 @@ export function HypercertCreateFormInner(props: HypercertCreateFormProps) {
         }}
         enableReinitialize
         onSubmit={async (values, { setSubmitting, setErrors }) => {
-          const image = await exportAsImage(IMAGE_SELECTOR);
           if (!address) {
             console.log("User not connected");
             return;
           }
+
+          console.log("Form values:");
+          console.log(values);
+          const image = await exportAsImage(IMAGE_SELECTOR);
           const {
             valid,
             errors,
@@ -358,7 +361,17 @@ export function HypercertCreateFormInner(props: HypercertCreateFormProps) {
             }}
           >
             <FormContext.Provider value={formikProps}>
-              <form onSubmit={formikProps.handleSubmit}>{children}</form>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  console.log("Submitting form...");
+                  console.log("Form errors:");
+                  console.log(formikProps.errors);
+                  formikProps.handleSubmit();
+                }}
+              >
+                {children}
+              </form>
             </FormContext.Provider>
           </DataProvider>
         )}


### PR DESCRIPTION
* Added text in the dialog to ask user to not close the tab while minting
* For some reason the page was reloading when I submitted the create form. Fixed via e.preventDefault
* Printing some debug messages around the create form
* Includes Plasmic updates
* Properly parameterize the GraphQL query to load my tokens (previously hardcoded address)