### PR TITLE
fix: Disable preview mode in Plasmic

### DIFF
--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -27,7 +27,7 @@ export const PLASMIC = initPlasmicLoader({
   ],
   // Fetches the latest revisions, whether or not they were unpublished!
   // Disable for production to ensure you render only published changes.
-  preview: true,
+  preview: false,
 });
 
 /**


### PR DESCRIPTION
* What does this mean? Builds will only pull the latest published version.
* Previously builds would pull the latest from Studio, regardless of whether it was published or not --- good for rapid development but terrible for stability
* If you are making changes to Plasmic and *no* code changes, nothing changes about your workflow.
* If you are making changes to code and not Plasmic, nothing changes either.
* If you are a developer making simultaneous changes to Plasmic and code components, you now have to remember to publish a Plasmic version before pushing your code to a PR.