### PR TITLE
fix: hypercert create form

### DIFF
--- a/frontend/components/forms.tsx
+++ b/frontend/components/forms.tsx
@@ -201,12 +201,13 @@ export interface FormDatePickerProps {
   label?: string; // Label to show
   showUndefined?: boolean; // Show a checkbox that allows date to be undefined
   defaultUndefined?: boolean; // Set undefined by default
+  disabled?: boolean; // disable this
 }
 
 export const DATE_INDEFINITE = "indefinite";
 export type DateIndefinite = "indefinite";
 export function FormDatePicker(props: FormDatePickerProps) {
-  const { className, fieldName, label, showUndefined, defaultUndefined } =
+  const { className, fieldName, label, showUndefined, defaultUndefined, disabled } =
     props;
   const [dateUndefined, setDateUndefinedRaw] = React.useState<boolean>(
     !!defaultUndefined,
@@ -255,6 +256,7 @@ export function FormDatePicker(props: FormDatePickerProps) {
           variant: "outlined",
           error: hasError,
           helperText: errorMessage,
+          disabled,
           style: {
             ...(showUndefined && dateUndefined ? { display: "none" } : {}),
           },

--- a/frontend/components/hypercert-create.tsx
+++ b/frontend/components/hypercert-create.tsx
@@ -41,7 +41,7 @@ const DEFAULT_FORM_DATA: HypercertCreateFormData = {
   bannerUrl: "",
   //bannerImage: null,
   impactScopes: ["all"] as string[],
-  impactTimeStart: DEFAULT_TIME.format("YYYY-MM-DD"),
+  //impactTimeStart: DEFAULT_TIME.format("YYYY-MM-DD"),
   impactTimeEnd: DEFAULT_TIME.format("YYYY-MM-DD"),
   workScopes: "",
   workTimeStart: DEFAULT_TIME.format("YYYY-MM-DD"),
@@ -69,7 +69,7 @@ interface HypercertCreateFormData {
   bannerUrl: string;
   //bannerImage: File | null;
   impactScopes: string[];
-  impactTimeStart?: string;
+  //impactTimeStart?: string;
   impactTimeEnd?: string | DateIndefinite;
   workScopes: string;
   workTimeStart?: string;
@@ -395,9 +395,15 @@ const formatValuesToMetaData = (
   );
 
   // Mint certificate using contract
+  // NOTE: we are fixing the impactTimeStart to be the same as workTimeStart
+  const impactTimeframeStart = val.workTimeStart
+    ? new Date(val.workTimeStart).getTime() / 1000
+    : 0;
+  /**
   const impactTimeframeStart = val.impactTimeStart
     ? new Date(val.impactTimeStart).getTime() / 1000
     : 0;
+  */
   const impactTimeframeEnd =
     val.impactTimeEnd !== "indefinite" && val.impactTimeEnd !== undefined
       ? new Date(val.impactTimeEnd).getTime() / 1000

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -223,6 +223,7 @@ PLASMIC.registerComponent(FormDatePicker, {
     label: "string",
     showUndefined: "boolean",
     defaultUndefined: "boolean",
+    disabled: "boolean",
   },
   importPath: "./components/forms",
 });


### PR DESCRIPTION
* Add a disabled option to DatePickers
* Remove the impactTimeStart from the form. Just reuse workTimeStart as per https://github.com/Network-Goods/hypercerts/issues/169