### PR TITLE
fix: impactTimeEnd  validation in create form

### DIFF
--- a/frontend/components/forms.tsx
+++ b/frontend/components/forms.tsx
@@ -250,7 +250,7 @@ export function FormDatePicker(props: FormDatePickerProps) {
     formikProps &&
     formikProps.touched[fieldName] &&
     !!formikProps.errors[fieldName];
-  const errorMessage = hasError ? formikProps.errors[fieldName] : undefined;
+  const errorMessage = hasError ? formikProps.errors[fieldName] as string : undefined;
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -270,22 +270,32 @@ export function FormDatePicker(props: FormDatePickerProps) {
           },
         }}
       />
-      <FormControlLabel
-        style={{
-          ...(showUndefined ? {} : { display: "none" }),
-        }}
-        control={
-          <Checkbox
-            checked={dateUndefined}
-            value={dateUndefined}
-            disabled={disabled}
-            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-              setDateUndefined(evt.target.checked);
-            }}
-          />
+      <FormControl
+        error={hasError}
+      >
+        <FormControlLabel
+          style={{
+            ...(showUndefined ? {} : { display: "none" }),
+          }}
+          control={
+            <Checkbox
+              checked={dateUndefined}
+              value={dateUndefined}
+              disabled={disabled}
+              onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                setDateUndefined(evt.target.checked);
+              }}
+            />
+          }
+          label="Indefinite End Date"
+        />
+        { 
+          // We need to show the error message here if the TextField above is hidden
+          hasError && dateUndefined
+            ? (<FormHelperText>{errorMessage}</FormHelperText>)
+            : <></>
         }
-        label="Indefinite End Date"
-      />
+      </FormControl>
     </LocalizationProvider>
   );
 

--- a/frontend/components/hypercert-create.tsx
+++ b/frontend/components/hypercert-create.tsx
@@ -203,8 +203,15 @@ const ValidationSchema = Yup.object().shape({
       }),
   ),
   impactScopes: Yup.array().min(1, "Please choose at least 1 item"),
-  impactTimeEnd: Yup.date().when(["workTimeStart"], (workTimeStart) => {
-    return Yup.date().min(workTimeStart, "End date must be after start date");
+  impactTimeEnd: Yup.lazy((val: any) => {
+    switch (typeof val) {
+      case "string":
+        return Yup.string().oneOf([DATE_INDEFINITE]);
+      default:
+        return Yup.date().when("workTimeStart", (workTimeStart) => {
+          return Yup.date().min(workTimeStart, "End date must be after start date");
+        });
+    }
   }),
   workScopes: Yup.string()
     .min(


### PR DESCRIPTION
* Adds an error label when we're in indefinite date. It was previously hidden with the textfield
* Change the validation logic to allow for mixed types string or Date for impactTimeEnd.